### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
+# DEPRECATED
+
+This conda recipe is no longer updated. The recommended way to install Open Babel with conda is via the conda-forge channel:
+
+    conda install -c conda-forge openbabel
+
+The Open Babel recipe is now maintained through conda-forge at the following links:
+
+- [Open Babel conda recipe](https://github.com/conda-forge/openbabel-feedstock)
+- [Open Babel on anaconda.org](https://anaconda.org/conda-forge/openbabel)
+
+---
+
 # conda-openbabel
+
 Conda build recipe for Open Babel


### PR DESCRIPTION
Following up on discussion in https://github.com/openbabel/conda-openbabel/issues/7

Some other possible tasks that may be helpful:

- [ ] Disable CI on this conda-openbabel repository
- [x] Add deprecation notice to package summary at https://anaconda.org/openbabel/openbabel
- [ ] Add deprecation notice to this conda-openbabel repository description on github
- [ ] "Archive" this repository in GitHub settings?
- [ ] Add a conda section to Open Babel installation docs
- [ ] Add a short installation summary to Open Babel README?